### PR TITLE
fix foodcritic warnings

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "bprobe"
 maintainer       "Boundary"
 maintainer_email "ops@boundary.com"
 license          "Apache 2.0"

--- a/providers/annotation.rb
+++ b/providers/annotation.rb
@@ -22,8 +22,10 @@ include Boundary::API
 
 action :create do
   annotate(new_resource)
+  new_resource.updated_by_last_action(true)
 end
 
 action :create_opsworks do
   create_opsworks_life_cycle_event_annotation(new_resource)
+  new_resource.updated_by_last_action(true)
 end

--- a/providers/certificates.rb
+++ b/providers/certificates.rb
@@ -65,7 +65,7 @@ def download_certificate_request(new_resource)
           owner "root"
           group "root"
           content cert_response.body
-          notifies :restart, resources(:service => "bprobe")
+          notifies :restart, "service[bprobe]"
         end
       else
         Chef::Log.error("Could not download certificate (nil response)!")
@@ -93,7 +93,7 @@ def download_key_request(new_resource)
           owner "root"
           group "root"
           content key_response.body
-          notifies :restart, resources(:service => "bprobe")
+          notifies :restart, "service[bprobe]"
         end
       else
         Chef::Log.error("Could not download key (nil response)!")

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -52,8 +52,8 @@ bprobe_annotation "bprobe-installation-opsworks" do
 end
 
 package "bprobe" do
-  notifies :create, resources(:bprobe_annotation => "bprobe-installation"), :immediately
-  notifies :create_opsworks, resources(:bprobe_annotation => "bprobe-installation-opsworks"), :immediately
+  notifies :create, "bprobe_annotation[bprobe-installation]", :immediately
+  notifies :create_opsworks, "bprobe_annotation[bprobe-installation-opsworks]", :immediately
 end
 
 # start the bprobe service
@@ -72,7 +72,7 @@ cookbook_file "#{node[:boundary][:bprobe][:etc][:path]}/ca.pem" do
   mode 0600
   owner "root"
   group "root"
-  notifies :restart, resources(:service => "bprobe")
+  notifies :restart, "service[bprobe]"
 end
 
 # enforce the main config file
@@ -81,6 +81,6 @@ template "#{node[:boundary][:bprobe][:etc][:path]}/bprobe.defaults" do
   mode 0644
   owner "root"
   group "root"
-  notifies :restart, resources(:service => "bprobe")
+  notifies :restart, "service[bprobe]"
 end
 

--- a/recipes/dependencies.rb
+++ b/recipes/dependencies.rb
@@ -53,7 +53,7 @@ when "ubuntu"
 
   apt_repository "boundary" do
     uri "https://apt.boundary.com/ubuntu/"
-    distribution node['lsb']['codename']
+    distribution node[:lsb][:codename]
     components ["universe"]
     key "https://apt.boundary.com/APT-GPG-KEY-Boundary"
     action :add
@@ -65,7 +65,7 @@ when "debian"
 
   apt_repository "boundary" do
     uri "https://apt.boundary.com/debian/"
-    distribution node['lsb']['codename']
+    distribution node[:lsb][:codename]
     components ["main"]
     key "https://apt.boundary.com/APT-GPG-KEY-Boundary"
     action :add


### PR DESCRIPTION
There is one more interesting warning left:
`FC024: Consider adding platform equivalents: cookbooks/bprobe/recipes/dependencies.rb:22`
