### PR TITLE
locking later versions of ubuntu to the precise apt repo

### DIFF
--- a/recipes/dependencies.rb
+++ b/recipes/dependencies.rb
@@ -59,7 +59,16 @@ when "debian"
 
   apt_repository "boundary" do
     uri "https://apt.boundary.com/ubuntu/"
-    distribution node[:lsb][:codename]
+    # precise is the latest version supported by the boundary repo,
+    # so force later versions (quantal and raring) to use that
+    case node[:lsb][:codename]
+    when "quantal"
+        distribution "precise"
+    when "raring"
+        distribution "precise"
+    else
+        distribution node[:lsb][:codename]
+    end
     components ["universe"]
     key "https://apt.boundary.com/APT-GPG-KEY-Boundary"
     action :add


### PR DESCRIPTION
Since the Boundary apt repo only has packages for Ubuntu 12.04 ("precise"), this small change allows later versions (12.10 "quantal" and 13.04 "raring") to still function by locking them to using the "precise" version.

It might be better to do this in a more generalized form (rather than hard-coding the names "quantal" and "raring"), but I don't know of a good way to do that in ruby.  At any rate, it seems like Boundary will hopefully get around to adding packages for the later versions to their apt repo sooner than another version of Ubuntu comes out that would necessitate another hard-coded case to be added to this code...
