### PR TITLE
Feature/interface support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,20 @@ override_attributes({
 })
 ````
 
+##### Interfaces
+
+By default, bprobe listens on all interfaces. However, you can manually specify the interfaces you wish to monitor.
+
+````
+override_attributes({
+  :boundary       => {
+    :bprobe       => {
+      :interfaces => [ "eth0", "eth2" ]
+    }
+  }
+})
+````
+
 ##### Annotations
 
 You can create annotations in the Boundary dashboard using this cookbook as well. By default this cookbook will create an annotation on installing and uninstalling bprobe.

--- a/attributes/bprobe.rb
+++ b/attributes/bprobe.rb
@@ -26,5 +26,5 @@ default[:boundary][:bprobe][:collector][:port] = "4740"
 
 default[:boundary][:bprobe][:tags] = []
 
-# The default is to listen on all interfaces
+# Array of interfaces to listen on, the default is to listen on all interfaces
 default[:boundary][:bprobe][:interfaces] = nil

--- a/attributes/bprobe.rb
+++ b/attributes/bprobe.rb
@@ -25,3 +25,6 @@ default[:boundary][:bprobe][:collector][:hostname] = "collector.boundary.com"
 default[:boundary][:bprobe][:collector][:port] = "4740"
 
 default[:boundary][:bprobe][:tags] = []
+
+# The default is to listen on all interfaces
+default[:boundary][:bprobe][:interfaces] = nil

--- a/templates/default/bprobe.defaults.erb
+++ b/templates/default/bprobe.defaults.erb
@@ -4,7 +4,7 @@ TLS_CA=<%= @node[:boundary][:bprobe][:etc][:path] %>/ca.pem
 TLS_CERT=<%= @node[:boundary][:bprobe][:etc][:path] %>/cert.pem
 <%- if node[:boundary][:bprobe][:interfaces] %>
 # http://support.boundary.com/customer/portal/articles/891583-manually-specify-interfaces-for-bprobe
-INTERFACES="<%= @node[:boundary][:bprobe][:interfaces] %>"
+INTERFACES="<%= @node[:boundary][:bprobe][:interfaces].join(' ') %>"
 <%- end -%>
 
 ## WARNING: Do not modify the values below unless

--- a/templates/default/bprobe.defaults.erb
+++ b/templates/default/bprobe.defaults.erb
@@ -2,6 +2,10 @@ PIDFILE=/var/run/bprobe.pid
 TLS_KEY=<%= @node[:boundary][:bprobe][:etc][:path] %>/key.pem
 TLS_CA=<%= @node[:boundary][:bprobe][:etc][:path] %>/ca.pem
 TLS_CERT=<%= @node[:boundary][:bprobe][:etc][:path] %>/cert.pem
+<%- if node[:boundary][:bprobe][:interfaces] %>
+# http://support.boundary.com/customer/portal/articles/891583-manually-specify-interfaces-for-bprobe
+INTERFACES="<%= @node[:boundary][:bprobe][:interfaces] %>"
+<%- end -%>
 
 ## WARNING: Do not modify the values below unless
 ## you know what you are doing!


### PR DESCRIPTION
Add support for manually specifying interfaces to monitor with bprobe

http://support.boundary.com/customer/portal/articles/891583-manually-specify-interfaces-for-bprobe
