### PR TITLE
Use FDQN attribute in Boundary namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,26 +2,27 @@
 
 This cookbook has two functions, the first is to install the Boundary bprobe daemon on your machine. The second is to interface with the Boundary API providing bprobe with certificates, adding the meter to your account and adding the meter to a group. The latter is provided by two LWRP's bprobe and bprobe_certificates. Examples of their usage can be found in the default recipe. This recipe can be used as is to install bprobe and configure it using the Boundary API. To get things running adjust the attributes in api.rb to match your Boundary account, upload the cookbooks in this repo and apply bprobe::default to a system.
 
-
 #### Dependencies
 
 This cookbook depends on the `apt` and `yum` cookbooks from https://github.com/boundary/boundary_cookbooks The Opscode maintained versions of these cookbooks *should* also work.
+
+#### Configuration Options
 
 ##### API Keys
 
 Setup your API keys in attributes/api.rb
 
-````
+```ruby
 default[:boundary][:api][:hostname] = "api.boundary.com"
 default[:boundary][:api][:org_id] = "dlekd93DGJDJw9diekd98"
 default[:boundary][:api][:key] = "PI1ldnfKENFMslekd29dl"
-````
+```
 
 ##### Host Tags
 
 The easiest way to set host tags is to use override_attributes in your server roles
 
-````
+```ruby
 name "db-server"
 description "Installs Boundary bprobe and sets some meter tags"
 recipes "mysql","bprobe::default"
@@ -33,13 +34,13 @@ override_attributes({
     }
   }
 })
-````
+```ruby
 
 ##### Interfaces
 
 By default, bprobe listens on all interfaces. However, you can manually specify the interfaces you wish to monitor.
 
-````
+```ruby
 override_attributes({
   :boundary       => {
     :bprobe       => {
@@ -47,12 +48,17 @@ override_attributes({
     }
   }
 })
-````
+```
 
-##### EC2
+##### Hostname
+
+By default Boundary will use `node[:fqdn]` as the hostname. You can override this by setting a `[:boundary][:hostname]` attribute with a higher precedence then default.
+
+#### EC2
 
 This cookbook includes automatic detection and tagging of your meter with various EC2 attributes such as security group and instance type.
 
-##### OpsWorks
+#### OpsWorks
 
 If you are using OpsWorks this cookbook should work out of the box (with the above dependencies). This cookbook also includes automatic detection and tagging of your meter with layers, stack name and applications if any exist.
+

--- a/attributes/api.rb
+++ b/attributes/api.rb
@@ -25,3 +25,5 @@ default[:boundary][:api][:org_id] = "yourid"
 
 # this is your api key (not the install token)
 default[:boundary][:api][:key] = "yourkey"
+
+default[:boundary][:fqdn] = node[:fqdn]

--- a/attributes/api.rb
+++ b/attributes/api.rb
@@ -26,4 +26,4 @@ default[:boundary][:api][:org_id] = "yourid"
 # this is your api key (not the install token)
 default[:boundary][:api][:key] = "yourkey"
 
-default[:boundary][:fqdn] = node[:fqdn]
+default[:boundary][:hostname] = node[:fqdn]

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "ops@boundary.com"
 license          "Apache 2.0"
 description      "Installs/Configures bprobe"
 long_description "Installs/Configures bprobe"
-version          "0.1"
+version          "0.2"
 
 %w{ ubuntu debian rhel centos amazon scientific }.each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,7 +22,7 @@
 include_recipe "bprobe::dependencies"
 
 # create the meter in the boundary api
-bprobe node[:boundary][:fqdn] do
+bprobe node[:boundary][:hostname] do
   action :create
 end
 
@@ -36,7 +36,7 @@ directory node[:boundary][:bprobe][:etc][:path] do
 end
 
 # download and install the meter cert and key files
-bprobe_certificates node[:boundary][:fqdn] do
+bprobe_certificates node[:boundary][:hostname] do
   action :install
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,7 +22,7 @@
 include_recipe "bprobe::dependencies"
 
 # create the meter in the boundary api
-bprobe node[:fqdn] do
+bprobe node[:boundary][:fqdn] do
   action :create
 end
 
@@ -36,7 +36,7 @@ directory node[:boundary][:bprobe][:etc][:path] do
 end
 
 # download and install the meter cert and key files
-bprobe_certificates node[:fqdn] do
+bprobe_certificates node[:boundary][:fqdn] do
   action :install
 end
 

--- a/recipes/delete.rb
+++ b/recipes/delete.rb
@@ -19,12 +19,12 @@
 #
 
 # delete the cert and key files on disk
-bprobe_certificates node[:boundary][:fqdn] do
+bprobe_certificates node[:boundary][:hostname] do
   action :delete
 end
 
 # delete the meter from the boundary api
-bprobe node[:boundary][:fqdn] do
+bprobe node[:boundary][:hostname] do
   action :delete
 end
 

--- a/recipes/delete.rb
+++ b/recipes/delete.rb
@@ -19,12 +19,12 @@
 #
 
 # delete the cert and key files on disk
-bprobe_certificates node[:fqdn] do
+bprobe_certificates node[:boundary][:fqdn] do
   action :delete
 end
 
 # delete the meter from the boundary api
-bprobe node[:fqdn] do
+bprobe node[:boundary][:fqdn] do
   action :delete
 end
 
@@ -35,4 +35,3 @@ end
 package "bprobe" do
   action :remove
 end
-


### PR DESCRIPTION
`node[:fqdn]` is set by ohai and has a highest precedence and "can not be modified" per http://docs.opscode.com/essentials_cookbook_attribute_files.html.

This changes the bprobe name to an attribute with a lower priority so it can be overwritten.
Eg `normal[:boundary][:hostname] = 'foo'`.

Also bumped the version number to make it possible to roll out the cookbook.
