### PR TITLE
There are breaking changes in the lastest version of the yum cookbook 

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -10,5 +10,5 @@ version          "0.1"
   supports os
 end
 
-depends "yum"
+depends "yum", "<= 2.4.4"
 depends "apt"


### PR DESCRIPTION
removal of the yum_key resource, pin to lower than v3
