### PR TITLE
Fix init not found problem and small changes for meter v3

### DIFF
--- a/attributes/bprobe.rb
+++ b/attributes/bprobe.rb
@@ -19,7 +19,7 @@
 #
 
 default[:boundary][:bprobe][:bin][:path] = "/usr/local"
-default[:boundary][:bprobe][:etc][:path] = "/etc/bprobe"
+default[:boundary][:bprobe][:etc][:path] = "/etc/boundary"
 
 default[:boundary][:bprobe][:collector][:hostname] = "collector.boundary.com"
 default[:boundary][:bprobe][:collector][:port] = "4740"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -41,11 +41,12 @@ bprobe_certificates node[:boundary][:hostname] do
 end
 
 # install the bprobe package
-package "bprobe" do
+package "boundary-meter" do
 end
 
 # start the bprobe service
 service "bprobe" do
+  service_name "boundary-meter"
   supports value_for_platform(
     "debian" => { "4.0" => [ :restart ], "default" => [ :restart ] },
     "ubuntu" => { "default" => [ :restart ] },


### PR DESCRIPTION
Making sure no errors are triggered on systems which use init scripts.
